### PR TITLE
some changes to illustrate other ways of doing things

### DIFF
--- a/api/src/pasteapi/paste.go
+++ b/api/src/pasteapi/paste.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"math/rand"
 	"time"
@@ -38,14 +39,17 @@ func RandStringRunes(n int) string {
 	return string(b)
 }
 
-func getPaste(id string) Paste {
-	var paste Paste
+var ErrPasteNotFound = errors.New("Paste not found")
 
-	if DB.Where("id = ?", id).First(&paste).RecordNotFound() {
-		log.Print("record not found")
-		return Paste{}
+func getPaste(id string) (*Paste, error) {
+	paste := &Paste{}
+
+	if DB.Where("id = ?", id).First(paste).RecordNotFound() {
+		log.Print("paste record not found")
+		return nil, ErrPasteNotFound
 	}
-	return paste
+
+	return paste, nil
 }
 
 func getPasteCount() int {
@@ -81,13 +85,13 @@ func savePaste(paste Paste) Paste {
 	return paste
 }
 
-func updatePaste(paste Paste) Paste {
-	DB.Model(&paste).Update("abuse", paste.Abuse)
+func updatePaste(paste *Paste) {
+	DB.Model(paste).Update("abuse", paste.Abuse)
 
 	if paste.Abuse == true {
 		var abuseEntry Abuse
 		abuseEntry.ClientIP = paste.ClientIP
 		saveAbuse(abuseEntry)
 	}
-	return paste
+
 }


### PR DESCRIPTION
This is minimally tested and isn't intended to be merged right in.

Here's a few things I found and how they could be done differently.

**Type Inference**
via the `:=` operator, Go will infer the type, so often you don't need to declare it to store a result in a variable:
```
var pastes []Paste
pastes = getPastesByUserToken(UserToken, false)
```
becomes
```
pastes := getPastesByUserToken(UserToken, false)
```

---

**Inline struct initialization**
Just some cleanup
```
var pasteResult PasteResult
pasteResult.Results = pastes
pasteResult.Count = len(pastes)
pasteResult.TotalCount = getPasteCount()
json.NewEncoder(w).Encode(pasteResult)
```
becomes
```
json.NewEncoder(w).Encode(&PasteResult{
  Results:    pastes,
  Count:      len(pastes),
  TotalCount: getPasteCount(),
})
```
This works well here because nothing you're using returns an error that you haven't dealt with.

---
**Pointers and Pass-By-Value**
Any discussion on pointers and Go will likely raise the point that "everything is pass by value in Go". Having said that, it matters *what* value you're passing. If you're passing a pointer around, that's different than the object itself.

This is important because pass-by-value means that your parameters are **copied** to the invoked function. You likely realized this with `updatePaste` where you passed in the struct itself and had to return it so you could receive the struct with the changes that the function made.

In doing that, it means that the entire struct is copied over to the new function, and then the resulting struct you return also has to be copied back to the function you invoked it from (main, in this case).

So with `updatePaste`, my change was to change it to accept `*Paste`, thus removing the need for the return. For reference, `updatePaste` was:
```
func updatePaste(paste Paste) Paste {
	DB.Model(&paste).Update("abuse", paste.Abuse)

	if paste.Abuse == true {
		var abuseEntry Abuse
		abuseEntry.ClientIP = paste.ClientIP
		saveAbuse(abuseEntry)
	}
	return paste
}
```

And I changed it to:
```
func updatePaste(paste *Paste) {
	DB.Model(paste).Update("abuse", paste.Abuse)

	if paste.Abuse == true {
		var abuseEntry Abuse
		abuseEntry.ClientIP = paste.ClientIP
		saveAbuse(abuseEntry)
	}

}
```
I would also change `saveAbuse` to accept a `*Paste` as well.

In general, I'm in the habit of always using pointers with my structs. The performance trade-offs between passing the struct versus the pointer around come in when you have a very large struct. There is still a cost to passing around pointers (indirection), but one of the Go authors described it as prioritizing readability and consistency over the slight performance differences.

The basics of it are this: if you have a method that's going to modify a struct, you're better off passing it as a pointer. And like I said above, I always just use pointers because it feels cleaner and more readable to me. I also find that many of the standard library and third party methods require you to pass in a pointer anyway.

So you'll notice that I did the same with `getPaste`, changing it to return a pointer for consistency. You'll also notice in `getPaste` that I had it return an error type that I defined as `ErrPasteNotFound`. This would come more into play when adding some helper functions around the API - i.e. you could have a function automatically display the error message to the end user if there is one, etc. 

---

Those are the basics of some suggestions I've made with this PR. I have other ideas too (like for removing a lot of the manual API code in favor of one or two functions or structs), but this is a good start.